### PR TITLE
chore: pin GitHub actions to specific commit SHA

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,10 +12,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Set up Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
       with:
         xcode-version: "26" 
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: "26" 
         
@@ -78,7 +78,7 @@ jobs:
             CODE_SIGNING_REQUIRED=NO
 
       - name: Create Draft Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           draft: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

To proactively limit the impact of a compromised dependency, GitHub recommends that workflows pin dependency versions to a specific commit SHA. This will prevent malicious code added to a new or updated branch or tag from being automatically used.

In GitHub there’s a setting to “Require actions to be pinned to a full-length commit SHA” and we intend to enable this setting soon.

The changes in this PR were created using the [`pin-github-action`](https://github.com/mheap/pin-github-action) tool.


[GitHub blog post](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>